### PR TITLE
espaced angle brackets in README urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,28 @@ Documentation starts here:
 
 ### API ENDPOINTS
 
-| HTTP Verbs | Endpoints            | Action                                 |
-| ---------- | -------------------- | -------------------------------------- |
-| GET        | /auth/token/login    | To login to an existing account        |
-| GET        | /auth/token/logout   | Logout from account                    |
-| POST       | /auth/users/         | Register new user                      |
-| GET        | /cards/              | Gets list of all cards created         |
-| GET        | /cards/me/           | List all of the logged in user's cards |
-| POST       | /cards/me/           | Create a card for the logged in user   |
-| GET        | /cards/<card_id>/    | Get a specific card's details          |
-| PATCH      | /cards/<card_id>/    | Updates a specific card's details.     |
-| DELETE     | /cards/<card_id>/    | Delete's a specific card.              |
-| GET        | /cards/<username>/   | View a specific user's cards.          |
-| GET        | /cards/followed/     | Gets a list of followed user's cards.  |
-| POST       | /follower/<username> | Follow the given user.                 |
-| DELETE     | /unfollow/<username> | Unfollow the given user.               |
-| GET        | /like/<int:card_id>  | Will like/unlike given card.           |
-| GET        | /search              | Search for a card's tag(s).            |
-| GET        | /comment/            | Get a list of all comments             |
-| POST       | /comment/            | Create a new comment                   |
-| GET        | /comments/<int:pk>/  | View a Specific comment                |
-| PUT        | /comments/<int:pk>/  | Updates the comment with specified id  |
-| DELETE     | /comments/<int:pk>/  | Deletes comment with specific id       |
+| HTTP Verbs | Endpoints               | Action                                 |
+| ---------- | ----------------------- | -------------------------------------- |
+| GET        | /auth/token/login       | To login to an existing account        |
+| GET        | /auth/token/logout      | Logout from account                    |
+| POST       | /auth/users/            | Register new user                      |
+| GET        | /cards/                 | Gets list of all cards created         |
+| GET        | /cards/me/              | List all of the logged in user's cards |
+| POST       | /cards/me/              | Create a card for the logged in user   |
+| GET        | /cards/\<card_id\>/     | Get a specific card's details          |
+| PATCH      | /cards/\<card_id\>/     | Updates a specific card's details.     |
+| DELETE     | /cards/\<card_id\>/     | Delete's a specific card.              |
+| GET        | /cards/\<username\>/    | View a specific user's cards.          |
+| GET        | /cards/followed/        | Gets a list of followed user's cards.  |
+| POST       | /follower/\<username\>/ | Follow the given user.                 |
+| DELETE     | /unfollow/\<username\>/ | Unfollow the given user.               |
+| GET        | /like/\<int:card_id\>/  | Will like/unlike given card.           |
+| GET        | /search                 | Search for a card's tag(s).            |
+| GET        | /comment/               | Get a list of all comments             |
+| POST       | /comment/               | Create a new comment                   |
+| GET        | /comments/\<int:pk\>/   | View a Specific comment                |
+| PUT        | /comments/\<int:pk\>/   | Updates the comment with specified id  |
+| DELETE     | /comments/\<int:pk\>/   | Deletes comment with specific id       |
 
 ## Register a new user
 


### PR DESCRIPTION
Fixed the issue of angle brackets not displaying in 'rendered blob' API Endpoints table.