### PR TITLE
now using djoser user profile endpoint, followed list now returns list, not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Documentation starts here:
 | GET        | /auth/token/login               | To login to an existing account        |
 | GET        | /auth/token/logout              | Logout from account                    |
 | POST       | /auth/users/                    | Register new user                      |
+| GET        | /auth/users/me/                 | User profile                           |
 | GET        | /cards/                         | Gets list of all cards created         |
 | GET        | /cards/me/                      | List all of the logged in user's cards |
 | POST       | /cards/me/                      | Create a card for the logged in user   |
@@ -42,7 +43,7 @@ Documentation starts here:
 Username and password are required.
 
 ```txt
-POST auth/users/
+POST /auth/users/
 ```
 
 ```json
@@ -70,7 +71,7 @@ POST auth/users/
 ### request
 
 ```txt
-POST auth/token/login
+POST /auth/token/login/
 ```
 
 ```json
@@ -95,13 +96,45 @@ POST auth/token/login
 ### request
 
 ```txt
-POST auth/token/logout
+POST /auth/token/logout/
 ```
 
 ```json
 204 No Content
 
 No body returned for response
+```
+
+## User profile page for logged in user
+
+### request
+
+```txt
+GET auth/users/me/
+```
+
+### response
+
+```json
+200 OK
+
+{
+	"id": 3,
+	"username": "capel",
+	"first_name": "",
+	"last_name": "",
+	"followed_list": [
+		{
+			"followed": "daniel"
+		},
+		{
+			"followed": "jacob"
+		},
+		{
+			"followed": "lucian"
+		}
+	]
+}
 ```
 
 ## List all cards for all users
@@ -111,6 +144,8 @@ No body returned for response
 ```txt
 GET /cards/
 ```
+
+### response
 
 ```json
 200 OK

--- a/config/settings.py
+++ b/config/settings.py
@@ -180,3 +180,9 @@ TAGGIT_CASE_INSENSITIVE = True
 CORS_ALLOW_HEADERS = list(default_headers) + [
     'content-disposition',
 ]
+
+DJOSER = {
+    'SERIALIZERS': {
+        'current_user': 'social_cards.serializers.UserSerializer',
+    },
+}

--- a/social_cards/serializers.py
+++ b/social_cards/serializers.py
@@ -3,8 +3,16 @@ from .models import User, SocialCard, Follower, Comments
 from taggit.serializers import TagListSerializerField, TaggitSerializer
 
 
+class FollowedListSerializer(serializers.ModelSerializer):
+    followed = serializers.SlugRelatedField(slug_field='username', read_only=True)
+
+    class Meta:
+        model = Follower
+        fields = ('followed',)
+
+
 class UserSerializer(serializers.ModelSerializer):
-    followed_list = serializers.CharField()
+    followed_list = FollowedListSerializer(many=True, source='LoggedInUser')
 
     class Meta:
         model = User

--- a/social_cards/views.py
+++ b/social_cards/views.py
@@ -72,6 +72,7 @@ class CardDetail(RetrieveUpdateDestroyAPIView):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
+        breakpoint()
         if self.request.method == 'GET':
             return SocialCard.objects.all()
         return SocialCard.objects.filter(owner=self.request.user)


### PR DESCRIPTION
The user profile endpoint is now the djoser user profile endpoint, and a custom serializer was used to return followed_list in the user profile. Tested locally via Insomnia. Documentation has been updated.